### PR TITLE
Add Applicative and Alternative to MonadLib.Derive

### DIFF
--- a/src/MonadLib/Derive.hs
+++ b/src/MonadLib/Derive.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE Rank2Types #-}
+
 {-| This module defines a number of functions that make it easy
 to get the functionality of MonadLib for user-defined newtypes.
 -}


### PR DESCRIPTION
Not really sure about the names of derive_apply and derive_or.
