### PR TITLE
Add safe haskell markings

### DIFF
--- a/src/MonadLib.hs
+++ b/src/MonadLib.hs
@@ -2,6 +2,7 @@
              UndecidableInstances, FlexibleInstances #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE Trustworthy #-}
 {-| This library provides a collection of monad transformers that
     can be combined to produce various monads.
 -}

--- a/src/MonadLib/Derive.hs
+++ b/src/MonadLib/Derive.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE Safe #-}
 
 {-| This module defines a number of functions that make it easy
 to get the functionality of MonadLib for user-defined newtypes.

--- a/src/MonadLib/Monads.hs
+++ b/src/MonadLib/Monads.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE Safe #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-|  This module contains a collection of monads that
    are defined in terms of the monad transformers from
    "MonadLib".   The definitions in this module are

--- a/src/MonadLib4.hs
+++ b/src/MonadLib4.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE MultiParamTypeClasses,
              FlexibleInstances,
              FunctionalDependencies,
-             OverlappingInstances #-}
+             OverlappingInstances,
+             Safe #-}
 {-# OPTIONS_GHC -fallow-undecidable-instances #-}
 {-| This library provides a collection of monad transformers that
     can be combined to produce various monads.


### PR DESCRIPTION
Add Trustworthy to MonadLib, as it imports ST, but only uses its Monad instance, and Safe to everything else.
