### PR TITLE
Require Cabal-version 1.8

### DIFF
--- a/monadLib.cabal
+++ b/monadLib.cabal
@@ -9,7 +9,7 @@ Category:       Monads
 Synopsis:       A collection of monad transformers.
 Description:    A collection of monad transformers.
 Build-type:     Simple
-Cabal-version: >= 1.2
+Cabal-version: >= 1.8
 Extra-source-files:
   LICENSE,
   README,


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: monadLib.cabal:25:30: version operators used. To use version
operators the package needs to specify at least 'cabal-version: >= 1.8'.
```